### PR TITLE
fix: file excluding

### DIFF
--- a/index.js
+++ b/index.js
@@ -532,10 +532,10 @@ module.exports = class {
       this.serverless.cli.log(message);
     });
 
-    const patterns = excludes
-      .map((p) => (p.charAt(0) === '!' ? p.substring(1) : `!${p}`))
-      .concat(includes)
-      .concat(fileList);
+    // Order is important, otherwise exclude flags will be overwritten
+    const patterns = includes
+      .concat(fileList)
+      .concat(excludes.map((p) => (p.charAt(0) === '!' ? p.substring(1) : `!${p}`)));
 
     const allFilePaths = await Globby(patterns, {
       cwd: this.servicePath,


### PR DESCRIPTION
**Problem statement:** once plugin is added to `serverless.yml`, `exclude` option in `package` doesn't work.
**Cause:** while calculating files to include in bundles excluded files are in the start of list and overwritten by list of all files.
